### PR TITLE
Remove stale Open Day, Future Bootcamps, and Newsletter

### DIFF
--- a/app/views/orders/form/_tickets.html.slim
+++ b/app/views/orders/form/_tickets.html.slim
@@ -8,7 +8,7 @@ h2
 - else
   - values = {}
 
-- trinkets = { community: { class: 'has-success', icon: 'users', help: 'Community Tickets are for individuals only, no corporate entities.' }, normal: { class: 'has-warning', icon: 'ticket', help: 'Normal tickets are for corporate customers or individuals who want to help our community efforts.' }, supporter: { class: 'has-error', icon: 'heart', help: 'Supporter tickets are for those who want to help our community efforts. All extra money that comes in goes back into the community effort to help more people code.' } }
+- trinkets = { community: { class: 'has-success', icon: 'users', help: 'Community Tickets are for individuals only, no corporate entities.' }, normal: { class: 'has-warning', icon: 'ticket', help: 'Through the corporate program we keep the community ticket price for individuals without access to financial assistance by employers as low as possible.' }, supporter: { class: 'has-error', icon: 'heart', help: 'Supporter tickets are for those who want to help our community efforts. All extra money that comes in goes back into the community effort to help more people code.' } }
 
 - @order.ticket_prices.each do |name, price|
   - discounted_price = price

--- a/app/views/orders/new.html.slim
+++ b/app/views/orders/new.html.slim
@@ -74,6 +74,8 @@
     /           | 5%
 
   - if @order.first_step?
+    = render 'shared/future_bootcamps'
+
     .dbc-container.dbc-text-cta.alt-color
       .inner.text
         h2

--- a/app/views/programs/index.html.slim
+++ b/app/views/programs/index.html.slim
@@ -171,3 +171,5 @@
         p
           = link_to 'Get tickets', tickets_path, class: 'button primary'
           = link_to 'Newsletter', newsletter_path, class: 'button default'
+
+    = render 'shared/future_bootcamps'

--- a/app/views/shared/_future_bootcamps.html.slim
+++ b/app/views/shared/_future_bootcamps.html.slim
@@ -1,0 +1,9 @@
+- cache 'future-bootcamps-cta' do
+  .dbc-container.dbc-text-cta.alt-color.light-color
+    .inner.normal
+      h2 Can't Join This Summer?
+      markdown:
+        Future bootcamps are being planned for October 2015 and January 2016.
+      p
+        = link_to 'Stay tuned', newsletter_path, class: 'button primary'
+

--- a/app/views/shared/_newsletter_form.html.slim
+++ b/app/views/shared/_newsletter_form.html.slim
@@ -1,0 +1,23 @@
+- cache 'newsletter-form' do
+  .dbc-container.dbc-text
+    .inner
+      form#mc-embedded-subscribe-form.validate action="//developmentbootcamp.us9.list-manage.com/subscribe/post?u=f107d6a3948661d72e4628ba1&amp;id=aff9cced90" method="post" name="mc-embedded-subscribe-form" novalidate="" target="_blank"
+        h2 Subscribe to our Newsletter
+        .form-group
+          label for="mce-FNAME" First Name
+          input#mce-FNAME.form-control name="FNAME" type="text" value="" /
+        .form-group
+          label for="mce-LNAME"  Last Name
+          input#mce-LNAME.form-control name="LNAME" type="text" value="" /
+        .form-group
+          label for="mce-EMAIL"
+            | Email Address
+            span.asterisk *
+          input#mce-EMAIL.required.email.form-control name="EMAIL" type="email" value="" /
+        /! real people should not fill this in and expect good things - do not remove this or risk form bot signups
+        div style=("position: absolute; left: -5000px;")
+          input name="b_f107d6a3948661d72e4628ba1_aff9cced90" tabindex="-1" type="text" value="" /
+        .clear
+          input#mc-embedded-subscribe.button.primary name="subscribe" type="submit" value="Subscribe" /
+          p
+            em You will receive an email to confirm your email address and subscription.

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -27,12 +27,6 @@
 
           See directions at the bottom of this page.
 
-        p
-          strong
-            | » Please note that the
-            =<> link_to 'Open Day', open_day_path
-            | is not at Science Park, but at Rokin 75.
-
         iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d2436.7869358646467!2d4.952404700000001!3d52.3561495!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c6094481e3bfeb%3A0xe7ebf26326a3be32!2sScience+Park+125%2C+1098+XG+Amsterdam!5e0!3m2!1sen!2snl!4v1432072548583" width="600" height="450" frameborder="0" style="border:0"
 
         p = link_to 'Google Maps', 'https://maps.google.com/maps?ll=52.356893,4.951899&z=16&t=m&hl=en-US&gl=NL&mapclient=embed&q=University%20of%20Amsterdam%20Science%20Park%20125%201098%20XG%20Amsterdam'

--- a/app/views/static_pages/home.html.slim
+++ b/app/views/static_pages/home.html.slim
@@ -45,63 +45,6 @@
         = link_to 'Program', program_path, class: 'button default'
         = link_to 'Tickets', tickets_path, class: 'button primary'
 
-  .dbc-container.dbc-text
-    .inner.caps
-      p
-        | Most people who code
-        mark =< 'never studied computer science.'
-        mark.alt-color =<> 'Most of them taught themselves.'
-        | That was hard, but we make it
-        mark =<> 'easy'
-        | for you to learn.
-
-      p = link_to 'Read full program', program_path, class: 'button primary'
-
-  .dbc-container.dbc-text-cta.alt-color.light-color
-    .inner.normal
-      h2 Code is Everywhere
-
-      markdown:
-        Every piece of technology that you use every day has software on it. Computers,
-        phones, cars, refrigerators, watches all run software large and small, complex
-        and simple. You probably want to play a role in that.
-
-      p
-        = link_to 'Program', program_path, class: 'button default'
-        = link_to 'Tickets', tickets_path, class: 'button primary'
-
-  .dbc-container.dbc-text
-    .inner.caps
-      p
-        mark.alt-color Once you know how it's done,
-        | you will see the opportunities.
-        mark =< 'And they are endless.'
-
-      p
-        mark.alt-color Programming is like any other thing in the world.
-        mark =<> "It's not hard"
-        | until you want to solve hard problems with it.
-
-      p = link_to 'Read full program', program_path, class: 'button primary'
-
-  .dbc-container.dbc-text-cta.alt-color
-    .inner.normal
-      h2 Learn Together
-
-      markdown:
-        It's more fun and inspiring to learn together. And
-        it goes a lot faster than learning code online.
-
-        We put real, working software engineers in front of
-        the classroom to give you the most up to date learning
-        experience available.
-
-      p
-        = link_to 'Program', program_path, class: 'button primary'
-        = link_to 'Tickets', tickets_path, class: 'button default'
-
-
-
   .dbc-container.dbc-text.dbc-day-at#day-structure
     .inner.normal
       h2 A Day at our Bootcamp
@@ -161,6 +104,61 @@
       p
         = link_to 'Program', program_path, class: 'button primary'
         = link_to 'Tickets', tickets_path, class: 'button default'
+
+  .dbc-container.dbc-text-cta.alt-color.light-color
+    .inner.normal
+      h2 Code is Everywhere
+
+      markdown:
+        Every piece of technology that you use every day has software on it. Computers,
+        phones, cars, refrigerators, watches all run software large and small, complex
+        and simple. You probably want to play a role in that.
+
+      p
+        = link_to 'Program', program_path, class: 'button default'
+        = link_to 'Tickets', tickets_path, class: 'button primary'
+
+  .dbc-container.dbc-text
+    .inner.caps
+      p
+        mark.alt-color Once you know how it's done,
+        | you will see the opportunities.
+        mark =< 'And they are endless.'
+
+      p
+        mark.alt-color Programming is like any other thing in the world.
+        mark =<> "It's not hard"
+        | until you want to solve hard problems with it.
+
+      p = link_to 'Read full program', program_path, class: 'button primary'
+
+  .dbc-container.dbc-text-cta.alt-color
+    .inner.normal
+      h2 Learn Together
+
+      markdown:
+        It's more fun and inspiring to learn together. And
+        it goes a lot faster than learning code online.
+
+        We put real, working software engineers in front of
+        the classroom to give you the most up to date learning
+        experience available.
+
+      p
+        = link_to 'Program', program_path, class: 'button primary'
+        = link_to 'Tickets', tickets_path, class: 'button default'
+
+  .dbc-container.dbc-text
+    .inner.caps
+      p
+        | Most people who code
+        mark =< 'never studied computer science.'
+        mark.alt-color =<> 'Most of them taught themselves.'
+        | That was hard, but we make it
+        mark =<> 'easy'
+        | for you to learn.
+
+      p = link_to 'Read full program', program_path, class: 'button primary'
 
   .dbc-content
     - cache 'testimonials-block' do

--- a/app/views/static_pages/home.html.slim
+++ b/app/views/static_pages/home.html.slim
@@ -213,3 +213,5 @@
                   .sponsor
                     = link_to sponsor_link do
                       = image_tag(sponsor.logo.thumb)
+
+    = render 'shared/newsletter_form'

--- a/app/views/static_pages/home.html.slim
+++ b/app/views/static_pages/home.html.slim
@@ -20,15 +20,15 @@
             mark = 'Amsterdam Science Park'
 
         p
-          => fa_icon 'comments'
+          => fa_icon 'bullhorn'
           strong
-            | Visit our
-            =< link_to 'Open Day', open_day_path
+            | Last
+            =< link_to 'Community Tickets', tickets_path
             br
-            | on June 19, 2015
+            | now for sale!
 
         p
-          = link_to 'Open Day', open_day_path, class: 'button default'
+          = link_to 'Program', program_path, class: 'button default'
           = link_to 'Tickets', tickets_path, class: 'button primary'
       .image
 

--- a/app/views/static_pages/home.html.slim
+++ b/app/views/static_pages/home.html.slim
@@ -192,14 +192,13 @@
                   | Ruben Timmerman,
                   cite =< link_to 'Springest', 'https://www.springest.nl/'
 
-    - cache 'sponsors-index-cta'
+    - cache 'home-corporate-cta'
       .dbc-container.dbc-text
         .inner.caps
             p
               | People in all tech companies can benefit from programming skills.
               mark.alt-color =< "Would you like to join us with your colleagues?"
               =< mail_to 'info@developmentbootcamp.nl', 'Send us an email.'
-
 
     - cache cache_key_for_sponsors do
       - if @sponsors.count > 0

--- a/app/views/static_pages/newsletter.html.slim
+++ b/app/views/static_pages/newsletter.html.slim
@@ -1,5 +1,5 @@
 - title "Students Newsletter Subscription"
-- meta_description "Subscribe to our Student's newsletter. Zero to developer in three sessions of a week."
+- meta_description "Subscribe to our newsletter. Zero to developer in three sessions of a week."
 - meta_keywords "newsletter, updated, development, bootcamp, programming, learn, student"
 
 - cache 'newsletter-signup' do
@@ -7,26 +7,34 @@
   .dbc-content
     .dbc-container.dbc-text-cta.light-color.alt-color
       .inner.normal
-        h2 Subscribe to our Students Newsletter
+        h2
+          mark => fa_icon 'bullhorn'
+          | Subscribe to our
+          mark =< 'Newsletter'
         p Leave your details below and we will keep you updated on our events, study materials, and promotions.
+
+        p
+          = link_to 'Subscribe', '#mc-embedded-subscribe-form', class: 'button primary'
 
     .dbc-container.dbc-text
       .inner
         form#mc-embedded-subscribe-form.validate action="//developmentbootcamp.us9.list-manage.com/subscribe/post?u=f107d6a3948661d72e4628ba1&amp;id=aff9cced90" method="post" name="mc-embedded-subscribe-form" novalidate="" target="_blank"
           h2 Subscribe to our mailing list
           .form-group
-            label for="mce-EMAIL"
-              | Email Address
-              span.asterisk *
-            input#mce-EMAIL.required.email.form-control name="EMAIL" type="email" value="" /
-          .form-group
             label for="mce-FNAME" First Name
             input#mce-FNAME.form-control name="FNAME" type="text" value="" /
           .form-group
             label for="mce-LNAME"  Last Name
             input#mce-LNAME.form-control name="LNAME" type="text" value="" /
+          .form-group
+            label for="mce-EMAIL"
+              | Email Address
+              span.asterisk *
+            input#mce-EMAIL.required.email.form-control name="EMAIL" type="email" value="" /
           /! real people should not fill this in and expect good things - do not remove this or risk form bot signups
           div style=("position: absolute; left: -5000px;")
             input name="b_f107d6a3948661d72e4628ba1_aff9cced90" tabindex="-1" type="text" value="" /
           .clear
             input#mc-embedded-subscribe.button.primary name="subscribe" type="submit" value="Subscribe" /
+            p
+              em You will receive an email to confirm your email address and subscription.

--- a/app/views/static_pages/newsletter.html.slim
+++ b/app/views/static_pages/newsletter.html.slim
@@ -16,25 +16,4 @@
         p
           = link_to 'Subscribe', '#mc-embedded-subscribe-form', class: 'button primary'
 
-    .dbc-container.dbc-text
-      .inner
-        form#mc-embedded-subscribe-form.validate action="//developmentbootcamp.us9.list-manage.com/subscribe/post?u=f107d6a3948661d72e4628ba1&amp;id=aff9cced90" method="post" name="mc-embedded-subscribe-form" novalidate="" target="_blank"
-          h2 Subscribe to our mailing list
-          .form-group
-            label for="mce-FNAME" First Name
-            input#mce-FNAME.form-control name="FNAME" type="text" value="" /
-          .form-group
-            label for="mce-LNAME"  Last Name
-            input#mce-LNAME.form-control name="LNAME" type="text" value="" /
-          .form-group
-            label for="mce-EMAIL"
-              | Email Address
-              span.asterisk *
-            input#mce-EMAIL.required.email.form-control name="EMAIL" type="email" value="" /
-          /! real people should not fill this in and expect good things - do not remove this or risk form bot signups
-          div style=("position: absolute; left: -5000px;")
-            input name="b_f107d6a3948661d72e4628ba1_aff9cced90" tabindex="-1" type="text" value="" /
-          .clear
-            input#mc-embedded-subscribe.button.primary name="subscribe" type="submit" value="Subscribe" /
-            p
-              em You will receive an email to confirm your email address and subscription.
+    = render 'shared/newsletter_form'

--- a/app/views/static_pages/open_day.html.slim
+++ b/app/views/static_pages/open_day.html.slim
@@ -7,17 +7,17 @@
   .dbc-content
     .dbc-container.dbc-text-cta.light-color.alt-color
       .inner.normal
-        h2 Visit our Open Day!
+        h2 Visit our one of our Open Days!
         p
-          | Leave your details below to register for our Open Day on
+          | Leave your details below to register for any of our
           strong
-            mark =<> 'June 19 at The View'
-          | (Rokin 75) in Amsterdam.
+            mark =<> 'Open Days'
+          | in Amsterdam. It will be a chance for you to ask all your questions.
+
         ul
-          li 15:00  — Keynote by Wouter de Vos (founder at Codaisseur and CTO at Springest)
+          li 15:00  — Keynote by Wouter de Vos
           li 16:00  — Workshop
-          li 17:00  — Ticket giveaway
-          li 17:15  — Q&A and drinks!
+          li 17:00  — Q&A and drinks!
 
         h3 &nbsp;
         iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2435.994430153673!2d4.893208999999993!3d52.370521!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c609c0ebbf6257%3A0xa8a5fb830684642e!2sRokin+75%2C+1012+KL+Amsterdam!5e0!3m2!1sen!2snl!4v1433436323983" width="600" height="450" frameborder="0" style="border:0"
@@ -40,9 +40,8 @@
           .form-group
             label for="mce-PHONE"  Phone Number
             input#mce-PHONE.form-control name="PHONE" type="text" value="" /
-            em Be sure to leave your phone number as that is your lottery number when we give away free tickets!
           /! real people should not fill this in and expect good things - do not remove this or risk form bot signups
           div style=("position: absolute; left: -5000px;")
             input name="b_f107d6a3948661d72e4628ba1_aff9cced90" tabindex="-1" type="text" value="" /
           .clear
-            input#mc-embedded-subscribe.button.primary name="subscribe" type="submit" value="Subscribe" /
+            input#mc-embedded-subscribe.button.primary name="subscribe" type="submit" value="Register" /


### PR DESCRIPTION
- Removed stale Open Day data
- Tweaks to the homepage
- CTA to subscribe to newsletter for open days
- Newsletter signup on the homepage
- Improved help text on corporate ticket prices