### PR TITLE
Fix discounts and Moneybird payments.

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -68,7 +68,7 @@ class Admin::OrdersController < Admin::AdminController
   end
 
   def order_params
-    params.require(:order).permit(:price, :payed_at, :mollie_payment_id, :refunded_at, :mollie_refund_id,
+    params.require(:order).permit(:price, :paid_at, :mollie_payment_id, :refunded_at, :mollie_refund_id,
       :billing_name, :billing_email, :billing_address, :billing_postal, :billing_city, :billing_country,
       :billing_phone, :billing_company_name, :confirmed_at, :terms_and_conditions,
       cart: [:community, :normal, :supporter],

--- a/db/migrate/20150625185616_add_invoice_id_to_orders.rb
+++ b/db/migrate/20150625185616_add_invoice_id_to_orders.rb
@@ -1,0 +1,5 @@
+class AddInvoiceIdToOrders < ActiveRecord::Migration
+  def change
+    add_column :orders, :invoice_id, :integer
+  end
+end

--- a/db/migrate/20150625195425_rename_orders_payed_at_to_paid_at.rb
+++ b/db/migrate/20150625195425_rename_orders_payed_at_to_paid_at.rb
@@ -1,0 +1,5 @@
+class RenameOrdersPayedAtToPaidAt < ActiveRecord::Migration
+  def change
+    rename_column :orders, :payed_at, :paid_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 20150701125843) do
 
   create_table "orders", force: true do |t|
     t.decimal  "price"
-    t.datetime "payed_at"
+    t.datetime "paid_at"
     t.string   "mollie_payment_id"
     t.string   "refunded_at"
     t.string   "mollie_refund_id"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20150701125843) do
     t.integer  "discount_code_id"
     t.text     "invoice_url"
     t.boolean  "paid_by_ideal",         default: false
+    t.integer  "invoice_id"
     t.integer  "bootcamp_id"
   end
 

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :order do
     bootcamp
-    payed_at { Time.now - 5.minutes }
+    paid_at { Time.now - 5.minutes }
     mollie_payment_id { 'tr_WDqYK6vllg' }
     refunded_at { Time.now - 2.minutes }
     mollie_refund_id { 'tr_WDqYK6aarb' }
@@ -61,7 +61,7 @@ FactoryGirl.define do
 
             factory :order_step_paid, class: 'Order' do
               price { cart_sum_total }
-              payed_at { Time.now - 5.minutes }
+              paid_at { Time.now - 5.minutes }
 
               factory :order_step_refund, class: 'Order' do
                 mollie_refund_id { 'tr_WDqYK6aarb' }


### PR DESCRIPTION
- Rename `Order#payed_at` to `Order#paid_at`
- Add discounts as an invoice row because we don't do discounts on community tickets and therefore can not use the discount option from Moneybird as it applies to the entire invoice.
- Post payments to Moneybird (does not work yet)