### PR TITLE
Migrate review avatars to uploaded images

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,4 +1,6 @@
 class Review < ActiveRecord::Base
+  mount_uploader :avatar, ReviewAvatarUploader
+
   belongs_to :student
   belongs_to :bootcamp
 

--- a/app/uploaders/review_avatar_uploader.rb
+++ b/app/uploaders/review_avatar_uploader.rb
@@ -1,0 +1,16 @@
+class ReviewAvatarUploader < ImageUploader
+  version :thumb do
+    process :set_original_sha
+    process convert: 'png'
+    process resize_and_pad_png: [100, 100]
+    process :set_content_type
+  end
+
+  def filename
+    if original_filename.present? && model.student.present?
+      "#{model.student.full_name.parameterize}-#{@original_sha}.png"
+    else
+      nil
+    end
+  end
+end

--- a/db/migrate/20151216093137_migrate_avatars_to_uploader.rb
+++ b/db/migrate/20151216093137_migrate_avatars_to_uploader.rb
@@ -1,0 +1,23 @@
+class MigrateAvatarsToUploader < ActiveRecord::Migration
+  def change
+    rename_column :reviews, :avatar, :original_avatar
+    add_column :reviews, :avatar, :string
+
+    migrate_avatars
+  end
+
+  def migrate_avatars
+    reviews = Review.all
+    reviews.each do |review|
+      original_avatar = review.original_avatar
+      next if original_avatar.blank?
+
+      # Let's use the built-in remote url support from
+      # Carrierwave here.
+      #
+      # See: https://github.com/carrierwaveuploader/carrierwave#/uploading-files-from-a-remote-location
+      review.remote_avatar_url = original_avatar
+      review.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151210174238) do
+ActiveRecord::Schema.define(version: 20151216093137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,7 +126,7 @@ ActiveRecord::Schema.define(version: 20151210174238) do
 
   create_table "reviews", force: true do |t|
     t.integer  "student_id"
-    t.string   "avatar"
+    t.string   "original_avatar"
     t.integer  "rating"
     t.integer  "bootcamp_id"
     t.text     "body"
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 20151210174238) do
     t.datetime "original_date"
     t.integer  "springest_id"
     t.string   "springest_author"
+    t.string   "avatar"
   end
 
   add_index "reviews", ["bootcamp_id"], name: "index_reviews_on_bootcamp_id", using: :btree


### PR DESCRIPTION
We have SSL issues with the images that are now often served over HTTP. By uploading them to our SSL cloud storage endpoints, we get full control over the image content as an added benefit.