### PR TITLE
Allergies section for Student Orders Form

### DIFF
--- a/app/views/orders/form/_students.html.slim
+++ b/app/views/orders/form/_students.html.slim
@@ -26,5 +26,4 @@
     = s.radio_button :owns_laptop, false, label: t(:form_label_no)
   = s.text_field :twitter_handle, required: false, placeholder: '@username', help: t(:form_optional)
   = s.text_field :github_handle, required: false, placeholder: '@username', help: t(:form_optional)
-  = s.text_area :allergies, required: false, placeholder: t('.placeholder_allergies'), help: t(:form_optional)
   = s.text_area :remarks, required: false, placeholder: t('.placeholder_remarks'), help: t(:form_optional)

--- a/app/workers/ticket_mail_worker.rb
+++ b/app/workers/ticket_mail_worker.rb
@@ -27,7 +27,6 @@ class TicketMailWorker < MailWorker
            { name: 'first_name', content: student.first_name, },
            { name: 'last_name', content: student.last_name, },
            { name: 'level', content: @order.bootcamp.level_name, },
-           { name: 'dietary_wishes', content: student.allergies || 'none', },
            { name: 'student_identifier', content: student.identifier, },
            { name: 'start_date', content: @order.bootcamp.starts_at.strftime("%B %e"), }
         ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,8 +39,6 @@ en:
         billing_city: City
         billing_country: Country
         billing_phone: Phone number
-      student:
-        allergies: Dietary wishes
       scholarship:
         full_program: Yes, I will make myself available for the 7 week immersive program
         traineeship: Yes, I am available for, and will participate in the 2 year, full time traineeship
@@ -383,7 +381,6 @@ en:
         placeholder_promo_code: Do you have a promo code? Paste it here..
       students:
         do_you_own_laptop: Do you own a laptop you can bring to class?
-        placeholder_allergies: E.g. do you have any allergies, are you a vegan?
         placeholder_remarks: Anything you'd like to add?
       confirmation:
         title: Confirmation

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -244,8 +244,6 @@ nl:
         billing_city: Stad
         billing_country: Land
         billing_phone: Telefoonnummer
-      student:
-        allergies: Dieetwensen
       scholarship:
         first_name: Voornaam
         last_name: Achternaam
@@ -624,7 +622,6 @@ nl:
         placeholder_promo_code: Heb je een kortingscode? Plak hem hier..
       students:
         do_you_own_laptop: Heb je een laptop die je mee kunt nemen naar de lessen?
-        placeholder_allergies: Heb je allergieën, ben je veganist?
         placeholder_remarks: Nog iets toe te voegen?
       confirmation:
         title: Confirmation

--- a/spec/views/orders/new.html.slim_spec.rb
+++ b/spec/views/orders/new.html.slim_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "orders/new", :type => :view do
 
         assert_select "form[action=?][method=?]", enroll_path, "post" do
           text_fields = [:first_name, :last_name, :twitter_handle, :github_handle, :phone_number]
-          text_areas = [:remarks, :allergies]
+          text_areas = [:remarks]
 
           text_fields.each do |f|
             assert_select "input#order_students_attributes_0_#{f}[name=?]", "order[students_attributes][0][#{f}]"


### PR DESCRIPTION
Remaining references to Allergies/Dietary Requirements have been removed from the forms. I thought that I had removed all references to this in a previous pull request but further testing proved otherwise.