### PR TITLE
Time and location

### DIFF
--- a/app/assets/stylesheets/components/_ticket.sass
+++ b/app/assets/stylesheets/components/_ticket.sass
@@ -86,3 +86,13 @@
 
         strong.discount
           color: $gray-lighter
+
+.ticket-caution
+  border: 1px solid #f0ad4e
+  background-color: #F8D9AC
+  padding: 0.8em
+  margin-bottom: 2em
+  border-radius: 6px
+  text-align: justify
+  font-weight: bold
+  font-style: italic

--- a/app/views/orders/form/_tickets.html.slim
+++ b/app/views/orders/form/_tickets.html.slim
@@ -8,6 +8,9 @@
     h1 = t(:title_pick_seats)
     = tmd(:tickets_intro)
 
+  .ticket-caution
+    = tmd(:tickets_caution, courses_url: courses_path)
+ 
 - if @bootcamps.count > 0
   .tickets#select_bootcamp
     = f.hidden_field :bootcamp_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,7 +254,11 @@ en:
 
   title_pick_seats: Pick a Ticket!
   tickets_intro: |
-    Select the level you want, and the number of seats you need on the class.
+    Select the level you want and the number of seats required for the course.
+  tickets_caution: |
+    Please note that all courses run from 9:30am to 6:00pm and take place in our training facility located at Weesperstraat 61 in Amsterdam. The
+    duration of each course varies; as such please review the respective [course page] (%{courses_url}) to ensure you understand the
+    time-requirements before purchasing.
   valid_on: Valid
   label_accept_terms: I have read and agree to the %{terms}, and the %{conditions}
   change_order: Change order

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,11 +188,10 @@ en:
   cta_apply_now: Yes please!
   cta_subscribe: Subscribe now
 
-  immersive_course_beginner: '_This is an immersive, full-time, 7 day course that starts on Sunday and ends on Saturday._'
-  immersive_course_intermediate: '_This is an immersive, full-time, 10 day course spanning a two week period. Classes run Monday to Friday during both weeks._'
-  immersive_course_advanced: '_This is an immersive, full-time, 11 day course spanning a two week period. Classes run Monday to Friday during the first week and Monday to Saturday during the second week._'
-  this_is_a_weekly_course: '_This is a weekly course that takes 7 weeks: one class per week and some homework on the weekends._'
-
+  immersive_course_beginner: '_This is an immersive, full-time, 7 day course that starts on Sunday and ends on Saturday. Classes start at 9:30am and end at 6:00pm and take place out our training facility located at Weesperstraat 61 in Amsterdam._'
+  immersive_course_intermediate: '_This is an immersive, full-time, 10 day course spanning a two week period.  Classes start at 9:30am and end at 6:00pm (Monday to Friday) and take place out our training facility located at Weesperstraat 61 in Amsterdam._'
+  immersive_course_advanced: '_This is an immersive, full-time, 11 day course spanning a two week period. Classes run Monday to Friday during the first week and Monday to Saturday during the second week,
+  9:30am to 6:30pm from our training facility located at Weesperstraat 61 in Amsterdam._'
   please_fix_errors_below: Please fix the errors below.
   please_mail_support: Please don't hesitate to email us at %{support_mail} if you have any questions or feedback! We would love to know :)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,7 +258,7 @@ en:
   tickets_caution: |
     Please note that all courses run from 9:30am to 6:00pm and take place in our training facility located at Weesperstraat 61 in Amsterdam. The
     duration of each course varies; as such please review the respective [course page] (%{courses_url}) to ensure you understand the
-    time-requirements before purchasing.
+    time-requirements.
   valid_on: Valid
   label_accept_terms: I have read and agree to the %{terms}, and the %{conditions}
   change_order: Change order

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -493,6 +493,10 @@ nl:
   title_pick_seats: Kies een ticket!
   tickets_intro: |
     Kies jouw niveau, en het aantal deelnemerplaatsen dat je wilt reserveren.
+  tickets_caution: |
+    Alle cursusdagen zijn van 9:30 tot 18:00 en worden gegeven op onze trainingslocatie
+    aan de Weesperstraat 61 in Amsterdam. De duur van de cursussen verschilt. Op de
+    respectievelijke cursuspagina vind je alle lesdagen.
   valid_on: geldig
   label_accept_terms: |
     Ik heb de %{terms} en %{conditions} gelezen en stem hiermee in.

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -418,9 +418,10 @@ nl:
   cta_subscribe: Meld je nu aan
 
   immersive_course_beginner: '_Dit is intensieve, voltijd, 7 dagense cursus
-  die begint op zondag en eindigt op zaterdag_'
-  immersive_course_intermediate: '_Dit is een intensieve, full-time cursus van 10 dagen verspreid over twee weken. Lessen vinden plaats van maandag t/m vrijdag gedurende beide weken._'
-  immersive_course_advanced: '_Dit is een intensieve, full-time cursus van 10 dagen verspreid over twee weken. Lessen vinden plaats van maandag t/m vrijdag gedurende de eerste week en van maandag t/m zaterdag gedurende de tweede week._'
+  die begint op zondag en eindigt op zaterdag. Lessen duren van 9:30 tot 18:00 en vinden plaats op onze trainingslocatie aan de Weesperstraat 61 te Amsterdam._'
+  immersive_course_intermediate: '_Dit is een intensieve, full-time cursus van 10 dagen verspreid over twee weken. Lessen duren van 9:30 tot 18:00 (maandag t/m vrijdag) en vinden plaats op onze trainingslocatie aan de Weesperstraat 61 te Amsterdam._'
+  immersive_course_advanced: '_Dit is een intensieve, full-time cursus van 10 dagen verspreid over twee weken. Lessen vinden plaats van maandag t/m vrijdag gedurende de eerste week en van maandag t/m zaterdag gedurende de tweede week,
+  9:30 tot 18:00 van onze trainingslocatie aan de Weesperstraat 61 te Amsterdam._'
   this_is_a_weekly_course: '_Dit is wekelijkse cursus van 7 weken: 1 les per week en wat huiswerk voor tijdens het weekend._'
 
   please_fix_errors_below: Corrigeer de onderstaande foutmeldingen.


### PR DESCRIPTION
Update course descriptions to include class times and location, including the addition of a similar message on the ticket page as reference. This was requested due to the number of support contacts enquiring about this information.

<img width="948" alt="ticket_caution" src="https://cloud.githubusercontent.com/assets/16960228/15241486/7a9712fe-18f0-11e6-837a-dfe32f0ccea5.png">
