### PR TITLE
example website links section disabled

### DIFF
--- a/app/views/programs/level_one.html.slim
+++ b/app/views/programs/level_one.html.slim
@@ -133,18 +133,18 @@
                   li Closing thoughts
         .row
           .col-xs-12
-            #examples.callout.callout-info
-              h3 = t('.what_you_can_build')
-
-              p = t('.wondering_what_others_built')
-
-              h4 = t('.examples_of_former_students')
-
-              ul
-                li = link_to 'Pomodoro Parrot', 'http://pomodoro.cloud.codaisseur.com', target: :blank
-                / li = link_to 'Coffee News', 'http://coffeenews.cloud.codaisseur.com', target: :blank
-                li = link_to 'Beer of the Week', 'http://beer.cloud.codaisseur.com/', target: :blank
-                li = link_to 'Got Sacked?', 'http://gotsacked.cloud.codaisseur.com/', target: :blank
+            / #examples.callout.callout-info
+            /   h3 = t('.what_you_can_build')
+            / 
+            /   p = t('.wondering_what_others_built')
+            / 
+            /   h4 = t('.examples_of_former_students')
+            / 
+            /   ul
+            /     li = link_to 'Pomodoro Parrot', 'http://pomodoro.cloud.codaisseur.com', target: :blank
+            /     / li = link_to 'Coffee News', 'http://coffeenews.cloud.codaisseur.com', target: :blank
+            /     li = link_to 'Beer of the Week', 'http://beer.cloud.codaisseur.com/', target: :blank
+            /     li = link_to 'Got Sacked?', 'http://gotsacked.cloud.codaisseur.com/', target: :blank
 
             = render 'enroll_cta'
 


### PR DESCRIPTION
All of the example website links on the beginner bootcamp course page are producing 404 errors:

<img width="738" alt="404s" src="https://cloud.githubusercontent.com/assets/16960228/15678930/576c88a4-2750-11e6-8417-2b0cc9887fd6.png">

Because the websites are stored in the Codaisseur cloud and I have no idea how to resolve this, I have commented out this section for the time being. I plan to update this section with some website projects from the traineeship students during this week.