### PR TITLE
Enroll page update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development, :test do
   gem 'guard-rspec'
   gem 'rb-fsevent'
   gem 'byebug'
+  gem 'faker'
 end
 
 group :test do

--- a/app/assets/stylesheets/components/_ticket.sass
+++ b/app/assets/stylesheets/components/_ticket.sass
@@ -87,12 +87,13 @@
         strong.discount
           color: $gray-lighter
 
-.ticket-caution
-  border: 1px solid #f0ad4e
-  background-color: #F8D9AC
-  padding: 0.8em
-  margin-bottom: 2em
-  border-radius: 6px
+.ticket-text
+  font-size: 1em
+  letter-spacing: 1px
   text-align: justify
-  font-weight: bold
-  font-style: italic
+
+.education-voucher
+  font-size: 2em
+  font-weight: lighter
+  letter-spacing: 1px
+  text-align: justify

--- a/app/assets/stylesheets/components/_titles.sass
+++ b/app/assets/stylesheets/components/_titles.sass
@@ -3,6 +3,10 @@
   margin: 100px 0 35px
   border-bottom: 1px solid $gray-light
 
+.sub-title
+  text-align: center
+  margin: 50px 0 35px
+
 h2
   font-size: 2.4em !important
 

--- a/app/views/orders/form/_tickets.html.slim
+++ b/app/views/orders/form/_tickets.html.slim
@@ -34,7 +34,7 @@
                 p
                   .old-price data-old-price=price.to_f = number_to_currency(price)
                   strong.discount #{@order.discount_code.discount_percentage}% DISCOUNT
-
+            = "incl. VAT / incl. BTW"
           .tear.tear-bottom
 
 .row

--- a/app/views/orders/form/_tickets.html.slim
+++ b/app/views/orders/form/_tickets.html.slim
@@ -8,8 +8,14 @@
     h1 = t(:title_pick_seats)
     = tmd(:tickets_intro)
 
-  .ticket-caution
+  .ticket-text
     = tmd(:tickets_caution, courses_url: courses_path)
+  
+  .sub-title
+    h2 = t(:title_education_voucher)
+  
+  .ticket-text
+    = tmd(:education_voucher_intro)
  
 - if @bootcamps.count > 0
   .tickets#select_bootcamp

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -259,6 +259,12 @@ en:
     Please note that all courses run from 9:30am to 6:00pm and take place in our training facility located at Weesperstraat 61 in Amsterdam. The
     duration of each course varies; as such please review the respective [course page] (%{courses_url}) to ensure you understand the
     time-requirements.
+  title_education_voucher: Education Voucher!!!
+  education_voucher_intro: |
+    Webdevelopment is considered a career opportunity with high prospects by the
+    Dutch Government. Therefore, enrollment in any of our programs entitles you
+    to an education voucher from the UWV. Click [here] (https://www.developmentbootcamp.com/pages/education-voucher-uwv)
+    for more information on what this means and how you can benefit!
   valid_on: Valid
   label_accept_terms: I have read and agree to the %{terms}, and the %{conditions}
   change_order: Change order

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -497,6 +497,13 @@ nl:
     Alle cursusdagen zijn van 9:30 tot 18:00 en worden gegeven op onze trainingslocatie
     aan de Weesperstraat 61 in Amsterdam. De duur van de cursussen verschilt. Op de
     respectievelijke [cursuspagina](%{courses_url}) vind je alle lesdagen.
+  title_education_voucher: Scholingsvoucher!!!
+  education_voucher_intro: |
+    Webdeveloper, evenals programmeur en testdeveloper is door de Nederlandse overheid
+    aangemerkt als een kansberoep. Dientengevolge kunt u in het kader van onze
+    opleidingen aanspraak maken op een scholingsvoucher van het UWV. Kijk [hier]
+    (https://www.developmentbootcamp.com/pages/education-voucher-uwv) voor
+    meer informatie en hoe je hier je voordeel mee kunt doen!
   valid_on: geldig
   label_accept_terms: |
     Ik heb de %{terms} en %{conditions} gelezen en stem hiermee in.


### PR DESCRIPTION
As requested by Rembert

- Added "incl. VAT/incl. BTW" to the bottom of each ticket

<img width="1020" alt="tickets" src="https://cloud.githubusercontent.com/assets/16960228/16620131/8a9b050e-4391-11e6-8db7-d12573dc35eb.png">

- Added education voucher snippet that will allow interested parties to travel to the static page with more info on the voucher.

<img width="1002" alt="voucher" src="https://cloud.githubusercontent.com/assets/16960228/16620155/a204be7e-4391-11e6-8a06-cdb76d00f25d.png">
