### PR TITLE
Voucher display in admin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
   - vendor/bundle
 rvm:
-- 2.1.5
+- 2.2.4
 addons:
   postgresql: '9.3'
 before_script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -516,8 +516,5 @@ DEPENDENCIES
   webmock
   wysiwyg-rails
 
-RUBY VERSION
-   ruby 2.2.4p230
-
 BUNDLED WITH
    1.12.5

--- a/app/models/moneybird/invoice.rb
+++ b/app/models/moneybird/invoice.rb
@@ -41,7 +41,7 @@ class Moneybird::Invoice < Moneybird::Api
 
       rows[rows.size.to_s] = row(
         amount: "#{amount} x",
-        description: "#{ticket.humanize} Ticket for #{order.bootcamp.name_with_dates}",
+        description: "Ticket for #{order.bootcamp.name_with_dates}",
         price: order.ticket_prices[ticket.to_sym]
       )
     end
@@ -55,7 +55,7 @@ class Moneybird::Invoice < Moneybird::Api
 
     if order.cart_discount > 0
       rows[rows.size.to_s] = row(
-        description: "Discount #{order.discount_code.discount_percentage}%",
+        description: "#{order.discount_code.code} (#{order.discount_code.discount_percentage}%)",
         price: -(order.cart_discount)
       )
     end

--- a/app/models/moneybird/invoice.rb
+++ b/app/models/moneybird/invoice.rb
@@ -41,7 +41,7 @@ class Moneybird::Invoice < Moneybird::Api
 
       rows[rows.size.to_s] = row(
         amount: "#{amount} x",
-        description: "Ticket for #{order.bootcamp.name_with_dates}",
+        description: "#{order.bootcamp.name_with_dates}",
         price: order.ticket_prices[ticket.to_sym]
       )
     end

--- a/app/views/admin/orders/index.html.slim
+++ b/app/views/admin/orders/index.html.slim
@@ -32,7 +32,9 @@
           span.label.label-warning =< order.payment.status
         - unless order.paid?
           =<> link_to 'Manually Paid', manually_paid_admin_order_path(order), method: :patch, class: 'btn btn-small'
-          = link_to 'Payment link', enroll_url(order), class: 'btn btn-small'
+          - if order.discount_code.present?
+            span.label.label-warning = "#{order.discount_code.code} (#{order.discount_code.discount_percentage}%)"
+          / = link_to 'Payment link', enroll_url(order), class: 'btn btn-small'
     - order.students.each do |student|
       .col-md-10
         .col-md-2


### PR DESCRIPTION
- Made it possible to see the voucher code used even if the order isn't paid.

- Changed invoice description to show the voucher code type and percentage and removed the ticket type so it just displays the bootcamp type.